### PR TITLE
Install dependencies using opam

### DIFF
--- a/b2piet.opam
+++ b/b2piet.opam
@@ -10,6 +10,7 @@ depends: [
   "conf-libpng"
   "integers"
   "lwt"
+  "ocamlbuild" {build}
   "ppx_deriving"
   "qcheck" {test}
 ]

--- a/b2piet.opam
+++ b/b2piet.opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+version: "dev"
+
+available: ocaml-version >= "4.03.0"
+depends: [
+  "atdgen"
+  "batteries"
+  "camlimages"
+  "cmdliner"
+  "conf-libpng"
+  "integers"
+  "lwt"
+  "ppx_deriving"
+  "qcheck" {test}
+]

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean metajsonml bytecode native test doc doc-default copycss
+.PHONY: all clean depends metajsonml bytecode native test doc doc-default copycss
 
 .DEFAULT: metajsonml bytecode
 
@@ -15,6 +15,11 @@ bytecode: metajsonml
 
 native: metajsonml
 	ocamlbuild -use-ocamlfind src/b2piet.native
+
+depends:
+	opam pin add --yes --no-action b2piet .
+	opam install --yes --unset-root --deps-only b2piet
+	opam pin remove b2piet
 
 clean:
 	rm -f src/metaJson_*


### PR DESCRIPTION
Nice project!

I'm sending this PR as a suggestion on improving the installation instructions a bit. I didn't dare edit the README – I think it's better for your own style to come through it :)

This PR is just a suggestion. You're welcome to incorporate any (zero or more) parts of it in any way you see fit, and don't bother with citing me as the author in any resulting commits :)

I'm concerned about the temporary pinning of `b2piet`, but I don't know a better way right now.

From the commit message:

```
After this commit, one can install all the dependencies by running

  make depends

This temporarily pins b2piet as an opam package, then installs all the
dependencies, without installing b2piet.

The main advantage of doing it this way is that opam will check the
compiler version, and it is possible to add version constraints on the
packages later.

The commit also lists package conf-libpng as a dependency. Installing
conf-libpng runs a check for the presence of libpng on the user's
system. If libpng is not installed, the user gets an error message with
instructions.

I am concerned that there is not an optional dependency from camlimages
on conf-libpng, which could, in principle, permit camlimages to be
compiled before the conf-libpng check is run. If that really is
possible, the problem should be fixed upstream in the opam repository.

I didn't update the README.
```